### PR TITLE
update gist instead of panicking when Wakatime statistics are not available yet.

### DIFF
--- a/pkg/box.go
+++ b/pkg/box.go
@@ -2,7 +2,6 @@ package wakabox
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -54,9 +53,8 @@ func (b *Box) GetStats(ctx context.Context) ([]string, error) {
 			max++
 		}
 		return lines, nil
-	} else {
-		return nil, errors.New("Insufficient statistics")
 	}
+	return []string{"Still Gathering Statistics..."}, nil
 }
 
 // GetGist gets the gist from github.com.


### PR DESCRIPTION
For new users Wakatime statistics are not available yet. Instead of panicking and the github action failing, update the gist reflecting that the statistics are still being gathered.