### PR TITLE
Styling options

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -14,9 +14,12 @@ jobs:
     name: Update-gist
     runs-on: ubuntu-latest
     env:
+          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GIST_ID: 9bc7025496e478f439b9cd43eba989a4
-          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+          GIST_BARSTYLE: SOLIDLT
+          GIST_BARLENGTH: -1
+          GIST_TIMESTYLE: SHORT
 
     steps:
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode
 .env

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ English | [简体中文](./README_zh.md)
 1. Edit the [environment variable](https://github.com/YouEclipse/waka-box-go/actions/runs/126970182/workflow#L17-L19) in `.github/workflows/schedule.yml`:
 
    - **GIST_ID:** The ID portion from your gist url: `https://gist.github.com/YouEclipse/`**`9bc7025496e478f439b9cd43eba989a4`**.
+   - **GIST_BARSTYLE:** Background of the progress bar. Default is "SOLIDLT" other options include "SOLIDMD", "SOLIDDK" for medium and dark backgrounds, "EMPTY" for blank background, and "UNDERSCORE" for a line along the bottom.
+   - **GIST_BARLENGTH:** Length of the progress bar. Default is 21. Set to -1 to auto size the bar.
+   - **GIST_TIMESTYLE** Abreviate the time text. Default is "LONG" ( "# hrs # mins" ). "SHORT" updates the text to "#h#m".
 
 1. Go to the repo **Settings > Secrets**
 1. Add the following environment variables:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ English | [简体中文](./README_zh.md)
    - **GIST_ID:** The ID portion from your gist url: `https://gist.github.com/YouEclipse/`**`9bc7025496e478f439b9cd43eba989a4`**.
    - **GIST_BARSTYLE:** Background of the progress bar. Default is "SOLIDLT" other options include "SOLIDMD", "SOLIDDK" for medium and dark backgrounds, "EMPTY" for blank background, and "UNDERSCORE" for a line along the bottom.
    - **GIST_BARLENGTH:** Length of the progress bar. Default is 21. Set to -1 to auto size the bar.
-   - **GIST_TIMESTYLE** Abreviate the time text. Default is "LONG" ( "# hrs # mins" ). "SHORT" updates the text to "#h#m".
+   - **GIST_TIMESTYLE** Abbreviate the time text. Default is "LONG" ( "# hrs # mins" ). "SHORT" updates the text to "#h#m".
 
 1. Go to the repo **Settings > Secrets**
 1. Add the following environment variables:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,13 @@ func main() {
 	ghUsername := os.Getenv("GH_USER")
 	gistID := os.Getenv("GIST_ID")
 
-	box := wakabox.NewBox(wakaAPIKey, ghUsername, ghToken)
+	style := wakabox.BoxStyle{
+		BarStyle:  os.Getenv("GIST_BARSTYLE"),
+		BarLength: os.Getenv("GIST_BARLENGTH"),
+		TimeStyle: os.Getenv("GIST_TIMESTYLE"),
+	}
+
+	box := wakabox.NewBox(wakaAPIKey, ghUsername, ghToken, style)
 
 	lines, err := box.GetStats(context.Background())
 	if err != nil {

--- a/pkg/box.go
+++ b/pkg/box.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -11,12 +12,39 @@ import (
 	"github.com/google/go-github/github"
 )
 
+// maxLineLength is the visible number of characters in a pinned gist box
+// (accounting for the clock emoji)
+const maxLineLength = 53
+
+// BarStyle defines valid styles for the progress bar
+var BarStyle = map[string][]rune{
+	"SOLIDLT":    []rune(`░▏▎▍▌▋▊▉█`),
+	"SOLIDMD":    []rune(`▒▏▎▍▌▋▊▉█`),
+	"SOLIDDK":    []rune(`▓▏▎▍▌▋▊▉█`),
+	"EMPTY":      []rune(` ▏▎▍▌▋▊▉█`),
+	"UNDERSCORE": []rune(`▁▏▎▍▌▋▊▉█`),
+}
+
+// BoxStyle contains information for initalizing a gist box style
+type BoxStyle struct {
+	BarStyle     string // Style of the progress bar as defined by BarStyle
+	BarLength    string // Length of the bar as a string (gets converted to an Int)
+	TimeStyle    string // Style of the time text. "SHORT" will be abbreviated.
+	barLengthInt int    // Set automatically from the Length defined above
+	maxLangLen   int    // Set automatically from the list of languages from wakatime
+	maxTimeLen   int    // Set automatically from the list of times from wakatime
+
+}
+
+// Box contains a github and wakatime client and styling information for the gist box
 type Box struct {
 	github   *github.Client
 	wakatime *wakatime.Client
+	style    BoxStyle
 }
 
-func NewBox(wakaAPIKey, ghUsername, ghToken string) *Box {
+// NewBox creates a box struct with appropriate wakatime and github information and gist styling information
+func NewBox(wakaAPIKey, ghUsername, ghToken string, style BoxStyle) *Box {
 	box := &Box{}
 
 	box.wakatime = wakatime.NewClient(wakaAPIKey, nil)
@@ -27,6 +55,16 @@ func NewBox(wakaAPIKey, ghUsername, ghToken string) *Box {
 	}
 	box.github = github.NewClient(tp.Client())
 
+	length, err := strconv.Atoi(style.BarLength)
+	if err != nil {
+		length = 21 //Default to 21
+	}
+	style.barLengthInt = length
+	if style.BarStyle == "" {
+		style.BarStyle = "SOLIDLT" // Default to SOLIDLT
+	}
+	box.style = style
+
 	return box
 }
 
@@ -36,22 +74,13 @@ func (b *Box) GetStats(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	max := 0
 
 	if languages := stats.Data.Languages; len(languages) > 0 {
-		lines := make([]string, 0)
-		for _, stat := range languages {
-			if max >= 5 {
-				break
-			}
-
-			line := pad(*stat.Name, " ", 9) + " " +
-				pad("🕓 "+*stat.Text, " ", 15) + " " +
-				GenerateBarChart(ctx, *stat.Percent, 21) + " " +
-				pad(fmt.Sprintf("%.1f%%", *stat.Percent), " ", 5)
-			lines = append(lines, line)
-			max++
+		lines, err := b.GenerateGistLines(ctx, languages)
+		if err != nil {
+			return nil, err
 		}
+
 		return lines, nil
 	}
 	return []string{"Still Gathering Statistics..."}, nil
@@ -63,7 +92,6 @@ func (b *Box) GetGist(ctx context.Context, id string) (*github.Gist, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return gist, nil
 }
 
@@ -73,10 +101,56 @@ func (b *Box) UpdateGist(ctx context.Context, id string, gist *github.Gist) erro
 	return err
 }
 
+// GenerateGistLines takes an slice of wakatime.StatItems, and generates a line for the gist.
+func (b *Box) GenerateGistLines(ctx context.Context, languages []wakatime.StatItem) ([]string, error) {
+	max := 0
+	lines := make([]string, 0)
+	for _, stat := range languages {
+		if b.style.TimeStyle == "SHORT" {
+			*stat.Text = convertDuration(*stat.Text)
+		}
+		if b.style.maxTimeLen < len(*stat.Text) {
+			b.style.maxTimeLen = len(*stat.Text)
+		}
+		if b.style.maxLangLen < len(*stat.Name) {
+			b.style.maxLangLen = len(*stat.Name)
+		}
+	}
+	if b.style.barLengthInt < 0 {
+		b.style.barLengthInt = maxLineLength - (b.style.maxLangLen + b.style.maxTimeLen + 10)
+	}
+	for _, stat := range languages {
+		if max >= 5 {
+			break
+		}
+		lines = append(lines, b.ConstructLine(ctx, stat))
+		max++
+	}
+	return lines, nil
+}
+
+// ConstructLine formats a gist line from stat infomation
+func (b *Box) ConstructLine(ctx context.Context, stat wakatime.StatItem) string {
+	return fmt.Sprintf("%-*s🕓 %-*s%s%5.1f%%",
+		b.style.maxLangLen+1, *stat.Name,
+		b.style.maxTimeLen+1, *stat.Text,
+		GenerateBarChart(ctx, *stat.Percent, b.style.barLengthInt, b.style.BarStyle),
+		*stat.Percent)
+}
+
 // GenerateBarChart generates a bar chart with the given percent and size.
-func GenerateBarChart(ctx context.Context, percent float64, size int) string {
+// Percent is a float64 from 0-100 representing the progress bar percentage
+// Size is an int representing the length of the progress bar in characters
+// BarType is a BarType representing the type of barchart: It can be one of the following:
+//    SOLIDLT SOLIDMD SOLIDDK: Block characters with a dotted background
+//    UNDERSCORE: Block characters with an line accross the boottom
+//    EMPTY: Block characters with an empty background
+func GenerateBarChart(ctx context.Context, percent float64, size int, barType string) string {
 	// using rune as for utf-8 encoding
-	var syms = []rune(`░▏▎▍▌▋▊▉█`)
+	syms := BarStyle[barType]
+	if len(syms) > 9 {
+		panic("No Syms")
+	}
 
 	frac := int(math.Floor((float64(size) * 8 * percent) / 100))
 	barsFull := int(math.Floor(float64(frac) / 8))
@@ -99,4 +173,15 @@ func pad(s, pad string, targetLength int) string {
 	}
 
 	return s + strings.Repeat(pad, padding)
+}
+
+func convertDuration(t string) string {
+	r := strings.NewReplacer(
+		"hr", "h",
+		"min", "m",
+		"sec", "s",
+		" ", "",
+		"s", "",
+	)
+	return r.Replace(t)
 }


### PR DESCRIPTION
Fixes issue where long languages would push the line too long (Javascript was one character too long)
Now, automatically sizes the line based on language length, and time length, and can automatically size bar to fit.

Adds additional styling options for the progress bar set through environment variables:
* GIST_BARSTYLE: "SOLIDLT" (default) "SOLIDMD" "SOLIDDK" "UNDERSCORE" and "EMPTY"
* GIST_BARLENGTH: 21 (default for backward compatibility), hard set to a specific length or set to -1 to automatically size
* GIST_TIMESTYLE: "LONG" (default) will use the standard time string from wakatime, "SHORT" will abbreviate it to "#h#m" (or just "#s" for "0 secs")